### PR TITLE
Wrapper a sync API of Emacs side and uncomment some unuseful code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 tags
 test.log
 workspace/
+*~

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ from utils import *
 eval_in_emacs("message", "hello from python-bridge")
 ```
 
+**Emacs side gets the return value of Python functions**:
+```python
+# Define this function in class PythonBridge.
+def echo(self, msg1, msg2):
+        eval_in_emacs("message", "%s %s", msg1, msg2)
+        return 1
+```
+
+```elisp
+(python-bridge-call--sync "echo" "hello" "world") ; Will return value 1 from Python function
+```
+Notice: Such Python function shouldn't use sync type python functions who call epc_client.call_sync(). Or there will be deadlock.
+
 **Python multithreading**:
 Please Google `Python threading` to learn how to use Python to write multithreaded code.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,19 @@ from utils import *
 eval_in_emacs("message", "hello from python-bridge")
 ```
 
+**Emacs 端调用 Python 方法**:
+```python
+# 在 class PythonBridge 中添加此测试方法
+def echo(self, msg1, msg2):
+        eval_in_emacs("message", "%s %s", msg1, msg2)
+        return 1
+```
+
+```elisp
+(python-bridge-call--sync "echo" "hello" "world") ; 在 Emacs 执行之后返回 1
+```
+注意：这类 Python 函数，如测试方法 echo，不能使用基于 epc_client.call_sync() 实现的方法（如 get_emacs_func_result），否则会导致死锁。
+
 **Python 多线程**:
 Python 多线程的方法请 Google `Python threading` 学习怎么使用 Python 来编写多线程代码。
 

--- a/python-bridge.el
+++ b/python-bridge.el
@@ -164,6 +164,13 @@ Then Python-Bridge will start by gdb, please send new issue with `*python-bridge
     (setq python-bridge-first-call-args args)
     ))
 
+(defun python-bridge-call--sync (method &rest args)
+  "Call Python EPC function METHOD and ARGS synchronously."
+  (if (python-bridge-epc-live-p python-bridge-epc-process)
+      (python-bridge-epc-call-sync python-bridge-epc-process (read method) args)
+    (message "python-bridge not started.")
+    ))
+
 (defvar python-bridge-first-call-method nil)
 (defvar python-bridge-first-call-args nil)
 

--- a/python_bridge.py
+++ b/python_bridge.py
@@ -50,15 +50,16 @@ class PythonBridge:
         self.server_thread.start()
         
         # All Emacs request running in event_loop.
-        self.event_queue = queue.Queue()
-        self.event_loop = threading.Thread(target=self.event_dispatcher)
-        self.event_loop.start()
+        # self.event_queue = queue.Queue()
+        # self.event_loop = threading.Thread(target=self.event_dispatcher)
+        # self.event_loop.start()
 
         # Pass epc port and webengine codec information to Emacs when first start python-bridge.
         eval_in_emacs('python-bridge--first-start', self.server.server_address[1])
 
         # event_loop never exit, simulation event loop.
-        self.event_loop.join()
+        # self.event_loop.join()
+        self.server_thread.join()
 
     def event_dispatcher(self):
         try:


### PR DESCRIPTION
1. The usage of self.event_queue is confusing for newbies such me.
2. Wrapper the sync API for less people who need it.
3. Add *~ in .gitignore.